### PR TITLE
feat: switch dbaserecordexception for endofstreamexception

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseRecord.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseRecord.cs
@@ -19,7 +19,7 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
 
             var flag = reader.ReadByte();
             if (flag == EndOfFile)
-                throw new DbaseRecordException("The end of file was reached unexpectedly.");
+                throw new EndOfStreamException("The end of file marker was reached.");
 
             if (flag != 0x20 && flag != 0x2A)
                 throw new DbaseRecordException(

--- a/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/AnonymousDbaseRecordTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/AnonymousDbaseRecordTests.cs
@@ -213,7 +213,8 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
                     var sut = new AnonymousDbaseRecord(new DbaseField[0]);
 
                     //Act
-                    Assert.Throws<DbaseRecordException>(() => sut.Read(reader));
+                    var exception = Assert.Throws<EndOfStreamException>(() => sut.Read(reader));
+                    Assert.Equal("The end of file marker was reached.", exception.Message);
                 }
             }
         }


### PR DESCRIPTION
different exception when observing endoffile marker

BREAKING CHANGE: different exception being thrown by dbaserecord.read()