### PR TITLE
feat: relax dbase file header reading

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseFileHeaderReadBehavior.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseFileHeaderReadBehavior.cs
@@ -1,0 +1,14 @@
+namespace Be.Vlaanderen.Basisregisters.Shaperon
+{
+    public class DbaseFileHeaderReadBehavior
+    {
+        public static readonly DbaseFileHeaderReadBehavior Default = new DbaseFileHeaderReadBehavior(false);
+
+        public DbaseFileHeaderReadBehavior(bool ignoreFieldOffset)
+        {
+            IgnoreFieldOffset = ignoreFieldOffset;
+        }
+
+        public bool IgnoreFieldOffset { get; }
+    }
+}

--- a/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseFileHeaderReadBehaviorTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseFileHeaderReadBehaviorTests.cs
@@ -1,0 +1,27 @@
+namespace Be.Vlaanderen.Basisregisters.Shaperon
+{
+    using AutoFixture;
+    using Xunit;
+
+    public class DbaseFileHeaderReadBehaviorTests
+    {
+        [Fact]
+        public void CtorInitializedProperties()
+        {
+            var fixture = new Fixture();
+            var value = fixture.Create<bool>();
+
+            var sut = new DbaseFileHeaderReadBehavior(value);
+
+            Assert.Equal(value, sut.IgnoreFieldOffset);
+        }
+
+        [Fact]
+        public void DefaultReturnsExpectedResult()
+        {
+            var sut = DbaseFileHeaderReadBehavior.Default;
+
+            Assert.False(sut.IgnoreFieldOffset);
+        }
+    }
+}


### PR DESCRIPTION
- allows to ignore field offsets which some files have set incorrectly
- the anonymous dbase schema will autocorrect them anyway