### PR TITLE
feat: hasvalue indication on non-nullable dbase values

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseBoolean.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseBoolean.cs
@@ -51,6 +51,8 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
             Value = value;
         }
 
+        public bool HasValue => _value.HasValue;
+
         public bool Value
         {
             get

--- a/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseDateTime.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseDateTime.cs
@@ -43,6 +43,8 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
             return true;
         }
 
+        public bool HasValue => _value != null;
+
         public DbaseDateTimeOptions Options { get; }
 
         private bool TryGetValue(out DateTime value)

--- a/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseDateTimeOffset.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseDateTimeOffset.cs
@@ -43,6 +43,8 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
             return true;
         }
 
+        public bool HasValue => _value != null;
+
         public DbaseDateTimeOffsetOptions Options { get; }
 
         private bool TryGetValue(out DateTimeOffset value)

--- a/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseDecimal.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseDecimal.cs
@@ -77,6 +77,8 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
             return rounded.ToString("F", Provider).Length <= Field.Length.ToInt32();
         }
 
+        public bool HasValue => _value.HasValue;
+
         public decimal Value
         {
             get

--- a/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseDouble.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseDouble.cs
@@ -74,6 +74,8 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
             return rounded.ToString("F", Provider).Length <= Field.Length.ToInt32();
         }
 
+        public bool HasValue => _value.HasValue;
+
         public double Value
         {
             get

--- a/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseInt16.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseInt16.cs
@@ -46,13 +46,12 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
             Value = value;
         }
 
-        public bool AcceptsValue(short? value)
+        public bool AcceptsValue(short value)
         {
-            if (value.HasValue)
-                return FormatAsString(value.Value).Length <= Field.Length.ToInt32();
-
-            return true;
+            return FormatAsString(value).Length <= Field.Length.ToInt32();
         }
+
+        public bool HasValue => _value.HasValue;
 
         public short Value
         {

--- a/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseInt32.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseInt32.cs
@@ -51,6 +51,8 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
             return FormatAsString(value).Length <= Field.Length.ToInt32();
         }
 
+        public bool HasValue => _value.HasValue;
+
         public int Value
         {
             get

--- a/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseSingle.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseSingle.cs
@@ -74,6 +74,8 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
             return rounded.ToString("F", Provider).Length <= Field.Length.ToInt32();
         }
 
+        public bool HasValue => _value.HasValue;
+
         public float Value
         {
             get

--- a/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseString.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseString.cs
@@ -27,6 +27,8 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
             return true;
         }
 
+        public bool HasValue => _value != null;
+
         public string Value
         {
             get => _value;

--- a/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/Customizations.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/Customizations.cs
@@ -697,6 +697,32 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
                         .OmitAutoProperties());
         }
 
+        public static void CustomizeDbaseStringWithoutValue(this IFixture fixture)
+        {
+            fixture.Customize<DbaseString>(
+                customization =>
+                    customization
+                        .FromFactory<int>(
+                            value =>
+                            {
+                                using (var random = new PooledRandom(value))
+                                {
+                                    var length = new DbaseFieldLength(random.Next(1, 255));
+                                    return new DbaseString(
+                                        new DbaseField(
+                                            fixture.Create<DbaseFieldName>(),
+                                            DbaseFieldType.Character,
+                                            fixture.Create<ByteOffset>(),
+                                            length,
+                                            new DbaseDecimalCount(0)
+                                        )
+                                    );
+                                }
+                            }
+                        )
+                        .OmitAutoProperties());
+        }
+
         public static void CustomizeDbaseInt32(this IFixture fixture)
         {
             fixture.Customize<DbaseInt32>(

--- a/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseBooleanTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseBooleanTests.cs
@@ -274,5 +274,20 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
             new GuardClauseAssertion(_fixture)
                 .Verify(new Methods<DbaseBoolean>().Select(instance => instance.Write(null)));
         }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithValue()
+        {
+            var sut = _fixture.Create<DbaseBoolean>();
+            Assert.True(sut.HasValue);
+        }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithoutValue()
+        {
+            _fixture.CustomizeDbaseBooleanWithoutValue();
+            var sut = _fixture.Create<DbaseBoolean>();
+            Assert.False(sut.HasValue);
+        }
     }
 }

--- a/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseDateTimeOffsetTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseDateTimeOffsetTests.cs
@@ -146,5 +146,20 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
                 }
             }
         }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithValue()
+        {
+            var sut = _fixture.Create<DbaseDateTimeOffset>();
+            Assert.True(sut.HasValue);
+        }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithoutValue()
+        {
+            _fixture.CustomizeDbaseDateTimeOffsetWithoutValue();
+            var sut = _fixture.Create<DbaseDateTimeOffset>();
+            Assert.False(sut.HasValue);
+        }
     }
 }

--- a/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseDateTimeTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseDateTimeTests.cs
@@ -146,5 +146,20 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
                 }
             }
         }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithValue()
+        {
+            var sut = _fixture.Create<DbaseDateTime>();
+            Assert.True(sut.HasValue);
+        }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithoutValue()
+        {
+            _fixture.CustomizeDbaseDateTimeWithoutValue();
+            var sut = _fixture.Create<DbaseDateTime>();
+            Assert.False(sut.HasValue);
+        }
     }
 }

--- a/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseDecimalTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseDecimalTests.cs
@@ -367,5 +367,20 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
                 }
             }
         }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithValue()
+        {
+            var sut = _fixture.Create<DbaseDecimal>();
+            Assert.True(sut.HasValue);
+        }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithoutValue()
+        {
+            _fixture.CustomizeDbaseDecimalWithoutValue();
+            var sut = _fixture.Create<DbaseDecimal>();
+            Assert.False(sut.HasValue);
+        }
     }
 }

--- a/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseDoubleTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseDoubleTests.cs
@@ -367,5 +367,20 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
                 }
             }
         }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithValue()
+        {
+            var sut = _fixture.Create<DbaseDouble>();
+            Assert.True(sut.HasValue);
+        }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithoutValue()
+        {
+            _fixture.CustomizeDbaseDoubleWithoutValue();
+            var sut = _fixture.Create<DbaseDouble>();
+            Assert.False(sut.HasValue);
+        }
     }
 }

--- a/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseInt16Tests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseInt16Tests.cs
@@ -264,5 +264,20 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
                 }
             }
         }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithValue()
+        {
+            var sut = _fixture.Create<DbaseInt16>();
+            Assert.True(sut.HasValue);
+        }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithoutValue()
+        {
+            _fixture.CustomizeDbaseInt16WithoutValue();
+            var sut = _fixture.Create<DbaseInt16>();
+            Assert.False(sut.HasValue);
+        }
     }
 }

--- a/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseInt32Tests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseInt32Tests.cs
@@ -261,5 +261,20 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
                 }
             }
         }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithValue()
+        {
+            var sut = _fixture.Create<DbaseInt32>();
+            Assert.True(sut.HasValue);
+        }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithoutValue()
+        {
+            _fixture.CustomizeDbaseInt32WithoutValue();
+            var sut = _fixture.Create<DbaseInt32>();
+            Assert.False(sut.HasValue);
+        }
     }
 }

--- a/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseSingleTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseSingleTests.cs
@@ -367,5 +367,20 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
                 }
             }
         }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithValue()
+        {
+            var sut = _fixture.Create<DbaseSingle>();
+            Assert.True(sut.HasValue);
+        }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithoutValue()
+        {
+            _fixture.CustomizeDbaseSingleWithoutValue();
+            var sut = _fixture.Create<DbaseSingle>();
+            Assert.False(sut.HasValue);
+        }
     }
 }

--- a/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseStringTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseStringTests.cs
@@ -204,5 +204,20 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
 
             Assert.Equal(accepted, result);
         }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithValue()
+        {
+            var sut = _fixture.Create<DbaseString>();
+            Assert.True(sut.HasValue);
+        }
+
+        [Fact]
+        public void HasValueReturnsExpectedResultWhenWithoutValue()
+        {
+            _fixture.CustomizeDbaseStringWithoutValue();
+            var sut = _fixture.Create<DbaseString>();
+            Assert.False(sut.HasValue);
+        }
     }
 }


### PR DESCRIPTION
This PR adds the ability to check whether the underlying value isn't `null` a.k.a. whether there is a value. This is useful when the validation and translation of dbase records lives in different places across the codebase.