### PR TITLE
feat: multipolygon support

### DIFF
--- a/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseIntegerDigits.cs
+++ b/src/Be.Vlaanderen.Basisregisters.Shaperon/DbaseIntegerDigits.cs
@@ -41,7 +41,10 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
         public override string ToString() => _value.ToString();
 
         [Pure]
-        public DbaseFieldLength ToLength() => new DbaseFieldLength(_value);
+        public DbaseFieldLength ToLength() => _value == 0
+            ? throw new InvalidOperationException("The conversion of this zero digit instance to a dbase field length is not possible. Dbase field length starts at 1.")
+            : new DbaseFieldLength(_value);
+
         public int CompareTo(DbaseIntegerDigits other) => _value.CompareTo(other._value);
 
         public static DbaseIntegerDigits operator +(DbaseIntegerDigits left, DbaseIntegerDigits right)

--- a/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseIntegerDigitsTests.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/DbaseIntegerDigitsTests.cs
@@ -74,12 +74,20 @@
         [Fact]
         public void ToLengthReturnsExpectedValue()
         {
-            var value = _fixture.Create<int>().AsDbaseIntegerDigitsValue();
+            var value = _fixture.Create<int>().AsDbaseFieldCompatibleDbaseIntegerDigitsValue();
             var sut = new DbaseIntegerDigits(value);
 
             var result = sut.ToLength();
 
             Assert.Equal(new DbaseFieldLength(sut.ToInt32()), result);
+        }
+
+        [Fact]
+        public void ToLengthThrowsWhenNoDigits()
+        {
+            var sut = new DbaseIntegerDigits(0);
+
+            Assert.Throws<InvalidOperationException>(() => sut.ToLength());
         }
 
         // [Fact]

--- a/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/Geometries/GeometryCustomizations.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/Geometries/GeometryCustomizations.cs
@@ -1,5 +1,6 @@
 namespace Be.Vlaanderen.Basisregisters.Shaperon.Geometries
 {
+    using System.Collections.Generic;
     using System.Linq;
     using AutoFixture;
 
@@ -109,6 +110,56 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon.Geometries
             );
         }
 
+        public static void CustomizeGeometryMultiPolygon(this IFixture fixture)
+        {
+            fixture.Customize<NetTopologySuite.Geometries.MultiPolygon>(customization =>
+                customization.FromFactory(generator =>
+                {
+                    var polygonCount = generator.Next(1, 4);
+                    var polygons = new NetTopologySuite.Geometries.Polygon[polygonCount];
+                    for (var polygonIndex = 0; polygonIndex < polygonCount; polygonIndex++)
+                    {
+                        var offsetX = 10.0 * polygonIndex;
+                        var offsetY = 10.0 * polygonIndex;
+
+                        var shell = new NetTopologySuite.Geometries.LinearRing(
+                            new []
+                            {
+                                new NetTopologySuite.Geometries.Point(offsetX, offsetY).Coordinate,
+                                new NetTopologySuite.Geometries.Point(offsetX, offsetY + 5.0).Coordinate,
+                                new NetTopologySuite.Geometries.Point(offsetX + 5.0, offsetY + 5.0).Coordinate,
+                                new NetTopologySuite.Geometries.Point(offsetX + 5.0, offsetY).Coordinate,
+                                new NetTopologySuite.Geometries.Point(offsetX, offsetY).Coordinate
+                            });
+
+                        var holes = new[] // points are enumerated counter clock wise
+                        {
+                            new NetTopologySuite.Geometries.LinearRing(
+                                new[]
+                                {
+                                    new NetTopologySuite.Geometries.Point(offsetX + 1.0, offsetY + 2.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 2.0, offsetY + 2.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 2.0, offsetY + 3.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 1.0, offsetY + 3.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 1.0, offsetY + 2.0).Coordinate
+                                }),
+                            new NetTopologySuite.Geometries.LinearRing(
+                                new[]
+                                {
+                                    new NetTopologySuite.Geometries.Point(offsetX + 3.0, offsetY + 1.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 4.0, offsetY + 1.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 4.0, offsetY + 2.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 3.0, offsetY + 2.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 3.0, offsetY + 1.0).Coordinate
+                                })
+                        };
+                        polygons[polygonIndex] = new NetTopologySuite.Geometries.Polygon(shell, holes, GeometryConfiguration.GeometryFactory);
+                    }
+                    return new NetTopologySuite.Geometries.MultiPolygon(polygons);
+                }).OmitAutoProperties()
+            );
+        }
+
         public static void CustomizePolygon(this IFixture fixture)
         {
             const int polygonExteriorBufferCoordinate = 50;
@@ -144,6 +195,81 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon.Geometries
                             points[index].X + polygonExteriorBufferCoordinate,
                             points[index].Y + polygonExteriorBufferCoordinate
                         );
+                    }
+
+                    var boundingBox = new BoundingBox2D(
+                        points.Min(p => p.X),
+                        points.Min(p => p.Y),
+                        points.Max(p => p.X),
+                        points.Max(p => p.Y)
+                    );
+                    return new Polygon(boundingBox, parts, points);
+                }).OmitAutoProperties()
+            );
+        }
+
+        public static void CustomizeMultiPolygon(this IFixture fixture)
+        {
+            fixture.Customize<Polygon>(customization =>
+                customization.FromFactory(generator =>
+                {
+                    var polygonCount = generator.Next(1, 4);
+                    var polygons = new NetTopologySuite.Geometries.Polygon[polygonCount];
+                    for (var polygonIndex = 0; polygonIndex < polygonCount; polygonIndex++)
+                    {
+                        var offsetX = 10.0 * polygonIndex;
+                        var offsetY = 10.0 * polygonIndex;
+
+                        var shell = new NetTopologySuite.Geometries.LinearRing(
+                            new []
+                            {
+                                new NetTopologySuite.Geometries.Point(offsetX, offsetY).Coordinate,
+                                new NetTopologySuite.Geometries.Point(offsetX, offsetY + 5.0).Coordinate,
+                                new NetTopologySuite.Geometries.Point(offsetX + 5.0, offsetY + 5.0).Coordinate,
+                                new NetTopologySuite.Geometries.Point(offsetX + 5.0, offsetY).Coordinate,
+                                new NetTopologySuite.Geometries.Point(offsetX, offsetY).Coordinate
+                            });
+
+                        var holes = new[] // points are enumerated counter clock wise
+                        {
+                            new NetTopologySuite.Geometries.LinearRing(
+                                new[]
+                                {
+                                    new NetTopologySuite.Geometries.Point(offsetX + 1.0, offsetY + 2.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 2.0, offsetY + 2.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 2.0, offsetY + 3.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 1.0, offsetY + 3.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 1.0, offsetY + 2.0).Coordinate
+                                }),
+                            new NetTopologySuite.Geometries.LinearRing(
+                                new[]
+                                {
+                                    new NetTopologySuite.Geometries.Point(offsetX + 3.0, offsetY + 1.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 4.0, offsetY + 1.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 4.0, offsetY + 2.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 3.0, offsetY + 2.0).Coordinate,
+                                    new NetTopologySuite.Geometries.Point(offsetX + 3.0, offsetY + 1.0).Coordinate
+                                })
+                        };
+                        polygons[polygonIndex] = new NetTopologySuite.Geometries.Polygon(shell, holes);
+                    }
+
+                    var linearRings = polygons
+                        .SelectMany(polygon => new[] {polygon.Shell}.Concat(polygon.Holes))
+                        .ToArray();
+                    var parts = new int[linearRings.Length];
+                    var points = new Point[polygons.Sum(polygon => polygon.Shell.NumPoints + polygon.Holes.Sum(hole => hole.NumPoints))];
+                    var offset = 0;
+                    for (var ringIndex = 0; ringIndex < linearRings.Length; ringIndex++)
+                    {
+                        var linearRing = linearRings[ringIndex];
+                        parts[ringIndex] = offset;
+                        for (var pointIndex = 0; pointIndex < linearRing.NumPoints; pointIndex++)
+                        {
+                            var point = linearRing.GetPointN(pointIndex);
+                            points[offset + pointIndex] = new Point(point.X, point.Y);
+                        }
+                        offset += linearRing.NumPoints;
                     }
 
                     var boundingBox = new BoundingBox2D(

--- a/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/Int32Extensions.cs
+++ b/test/Be.Vlaanderen.Basisregisters.Shaperon.Tests/Int32Extensions.cs
@@ -80,6 +80,11 @@ namespace Be.Vlaanderen.Basisregisters.Shaperon
             return new Random(value).Next(0, 255);
         }
 
+        public static int AsDbaseFieldCompatibleDbaseIntegerDigitsValue(this int value)
+        {
+            return new Random(value).Next(1, 255);
+        }
+
         public static byte AsDbaseCodePageValue(this byte value)
         {
             return DbaseCodePage.All[new Random(value).Next(0, DbaseCodePage.All.Length)].ToByte();


### PR DESCRIPTION
This PR adds support for converting between a Polygon (Shaperon|ShapeFiles) and a MultiPolygon (NTS). TransactionZones.shp typically store the boundaries of municipalities, which are multipolygons (multiple polygons) instead of polygons (one polygon with one shell and zero, one or many holes).

There's a bit of a mismatch between the Polygon model in shape files (list of linear rings) and MultiPolygon in NTS (list of polygons). Normally shells are stored in clock wise orientation and holes in counter clock wise orientation. Let's hope actual data respects this recommendation (see https://www.esri.com/library/whitepapers/pdfs/shapefile.pdf) because the conversion logic fully expects it. If that turns out not to be the case, we could try to detect which rings are covered by which other rings, coming up with polygons that way.